### PR TITLE
Prevent YT invites from displaying a preview

### DIFF
--- a/commands/Music System/youtube.js
+++ b/commands/Music System/youtube.js
@@ -7,7 +7,12 @@ module.exports = {
 	async execute(client, message, args) {
 		if (!message.member.voice.channel) return message.channel.send(require('../../messages.json').music_notconnected);
 		client.discordTogether.createTogetherCode(message.member.voice.channelID, 'youtube').then(async invite => {
-    			return message.channel.send(`${invite.code}`);
+			/**
+			 * Put the URL in <> to stop Discord from showing the (useless) preview
+			 * -> "Note: you have to click on the BLUE LINK, not the 'Play' button, in order to start the activity"
+			 * 	   https://www.npmjs.com/package/discord-together
+			 */
+			return message.channel.send(`<${invite.code}>`);
 		});
 	},
 };


### PR DESCRIPTION
As stated in the `discord-together` package's description, you need to click the blue URL instead of the green join button in the embed on youtube invites. This PR prevents that embed from displaying in the first place, to avoid confusion.

"Note: you have to click on the BLUE LINK, not the 'Play' button, in order to start the activity" (https://www.npmjs.com/package/discord-together)